### PR TITLE
modify url of Euslisp manual

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ This is document collection of euslisp application programs
 ## EusLisp
 
 - [github project page](http://github.com/euslisp/EusLisp)
-- [EusLisp manual](euslisp/manual)
+- [EusLisp manual](http://euslisp.github.io/EusLisp/manual.html)
 
 ## jskeus
 


### PR DESCRIPTION
I found a link to euslisp manual is missing.
When I accessed https://euslisp-docs.readthedocs.io/en/latest/ and clicked Euslisp manual, 404 error appeared.
Current link to euslisp manual is `euslisp/manual`, but there is no such folder in `euslisp-docs`.
I modified it to http://euslisp.github.io/EusLisp/manual.html based on [README.md from Euslisp/euslisp](https://github.com/euslisp/EusLisp).

